### PR TITLE
[BACKEND-806] Modifications for internal build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,42 +1,26 @@
 plugins {
     id 'nebula.netflixoss' version '2.2.5'
     id 'nebula.provided-base' version '2.0.1'
+    id "net.linguica.maven-settings" version "0.5"
 }
 
 ext.githubProjectName = rootProject.name // Change if github project name is not the same as the root project's name
 
+license {
+    ignoreFailures = true
+}
+
 subprojects {
     apply plugin: 'nebula.netflixoss'
     apply plugin: 'java'
+    apply plugin: 'net.linguica.maven-settings'
 
     group = "com.netflix.${githubProjectName}" // TEMPLATE: Set to organization of project
 
     repositories {
-        File settingsFile = new File(m2SettingsFile.replace('~', System.env.HOME.toString()))
-        if (settingsFile.isFile()) {
-            println "Detected m2 settings file: ${settingsFile}"
-            def settings = new XmlSlurper().parse(settingsFile)
-            def profiles = settings.activeProfiles.activeProfile
-            for (profile in profiles) {
-                def repos = settings.profiles.profile.find {
-                    p -> p.id.text() == profile.text()
-                }.repositories.repository
-                for (repo in repos) {
-                    def server = settings.servers.server.find {
-                        s -> s.id.text() == repo.id.text()
-                    }
-                    maven {
-                        credentials {
-                            username server.username.text()
-                            password server.password.text()
-                        }
-                        url repo.url.text()
-                    }
-                }
-            }
-        } else {
-            println 'No m2 settings detected'
-            jcenter()
+        maven {
+          name repoName
+          url repoUrl
         }
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,32 @@ subprojects {
     group = "com.netflix.${githubProjectName}" // TEMPLATE: Set to organization of project
 
     repositories {
-        jcenter()
+        File settingsFile = new File(m2SettingsFile.replace('~', System.env.HOME.toString()))
+        if (settingsFile.isFile()) {
+            println "Detected m2 settings file: ${settingsFile}"
+            def settings = new XmlSlurper().parse(settingsFile)
+            def profiles = settings.activeProfiles.activeProfile
+            for (profile in profiles) {
+                def repos = settings.profiles.profile.find {
+                    p -> p.id.text() == profile.text()
+                }.repositories.repository
+                for (repo in repos) {
+                    def server = settings.servers.server.find {
+                        s -> s.id.text() == repo.id.text()
+                    }
+                    maven {
+                        credentials {
+                            username server.username.text()
+                            password server.password.text()
+                        }
+                        url repo.url.text()
+                    }
+                }
+            }
+        } else {
+            println 'No m2 settings detected'
+            jcenter()
+        }
     }
 
     sourceCompatibility = 1.6

--- a/build.gradle
+++ b/build.gradle
@@ -18,9 +18,13 @@ subprojects {
     group = "com.netflix.${githubProjectName}" // TEMPLATE: Set to organization of project
 
     repositories {
-        maven {
-          name repoName
-          url repoUrl
+        if (project.hasProperty("repoName") && project.hasProperty("repoUrl")) {
+            maven {
+                name repoName
+                url repoUrl
+            }
+        } else {
+            jcenter()
         }
     }
 

--- a/exhibitor-core/build.gradle
+++ b/exhibitor-core/build.gradle
@@ -16,13 +16,19 @@ dependencies {
     compile "javax.ws.rs:jsr311-api:${jaxRsVersion}"
     compile "org.codehaus.jackson:jackson-mapper-asl:${jacksonVersion}"
     compile "org.apache.lucene:lucene-core:${luceneVersion}"
-    
+
     compile "com.sun.jersey:jersey-client:${jerseyVersion}"
 
     // if you are using Java 7 you can remove this and switch to the JDK version
     compile 'org.codehaus.jsr166-mirror:jsr166y:1.7.0'
 
-    compile "com.amazonaws:aws-java-sdk:${awsVersion}"
+    compile("com.amazonaws:aws-java-sdk:${awsVersion}") {
+      // remove joda-time dependency from aws-java-sdk because of non-deterministic
+      // dependent version
+      exclude group: 'joda-time', module: 'joda-time'
+    }
+    // added a fixed version of joda-time
+    compile "joda-time:joda-time:${jodaTimeVersion}"
     compile "com.sun.jersey:jersey-core:${jerseyVersion}"
     compile "com.sun.jersey:jersey-server:${jerseyVersion}"
     compile "com.sun.jersey:jersey-json:${jerseyVersion}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,6 +13,3 @@ luceneVersion=3.6.0
 awsVersion=1.9.3
 mockitoVersion=1.8.5
 jodaTimeVersion=2.9.9
-
-repoName=central
-repoUrl=https://repo1.maven.org/maven2

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,3 +13,5 @@ luceneVersion=3.6.0
 awsVersion=1.9.3
 mockitoVersion=1.8.5
 jodaTimeVersion=2.9.9
+
+m2SettingsFile=~/.m2/settings.xml

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,4 +14,5 @@ awsVersion=1.9.3
 mockitoVersion=1.8.5
 jodaTimeVersion=2.9.9
 
-m2SettingsFile=~/.m2/settings.xml
+repoName=central
+repoUrl=https://repo1.maven.org/maven2

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,3 +12,4 @@ jacksonVersion=1.8.3
 luceneVersion=3.6.0
 awsVersion=1.9.3
 mockitoVersion=1.8.5
+jodaTimeVersion=2.9.9


### PR DESCRIPTION
This modifies the build to:
1. fix the version of `joda-time` to `2.9.9` to ensure repeatable build
2. use (active) repositories configured in `settings.xml` (if available) for build